### PR TITLE
feat: add deploy pepeline command with required and optional flags

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,1 +1,17 @@
-[]
+[
+  {
+    "command": "deploy:pipeline",
+    "plugin": "@salesforce/plugin-devops-center",
+    "flags": [
+      "branch-name",
+      "bundle-version-name",
+      "deploy-all",
+      "devops-center-project-name",
+      "devops-center-username",
+      "json",
+      "test-level",
+      "tests"
+    ],
+    "alias": []
+  }
+]

--- a/messages/commonFlags.md
+++ b/messages/commonFlags.md
@@ -4,7 +4,7 @@ Name of the DevOps Center project.
 
 # promote.branch-name.summary
 
-Name of the branch from which to deploy changes to the stage’s org.
+Name of the branch in the source control repository from which to deploy changes to the stage’s org.
 
 # promote.deploy-all.summary
 
@@ -12,7 +12,7 @@ Deploy all metadata in branch.
 
 # promote.deploy-all.description
 
-If you don’t specify this flag, only changes in this stage’s branch are deployed.
+If you don’t specify this flag, only changes in the stage’s branch are deployed.
 
 # promote.devops-center-username.summary
 
@@ -24,7 +24,7 @@ Version name of the bundle.
 
 # promote.bundle-version-name.description
 
-Bundle version name when deploying to the first stage after the bundling stage.
+You must indicate the bundle version if deploying to the environment that correspond to the first stage after the bundling stage.
 
 # promote.tests.summary
 

--- a/messages/commonFlags.md
+++ b/messages/commonFlags.md
@@ -1,0 +1,53 @@
+# promote.devops-center-project-name.summary
+
+Name of the DevOps Center project.
+
+# promote.branch-name.summary
+
+Name of the branch from which to deploy changes to the stage’s org.
+
+# promote.deploy-all.summary
+
+Deploy all metadata in branch.
+
+# promote.deploy-all.description
+
+If you don’t specify this flag, only changes in this stage’s branch are deployed.
+
+# promote.devops-center-username.summary
+
+Username or alias for the DevOps Center org.
+
+# promote.bundle-version-name.summary
+
+Version name of the bundle.
+
+# promote.bundle-version-name.description
+
+Bundle version name when deploying to the first stage after the bundling stage.
+
+# promote.tests.summary
+
+Apex tests to run when --test-level is RunSpecifiedTests.
+
+# promote.tests.description
+
+Separate multiple test names with commas, and enclose the entire flag value in double quotes if a test contains a space.
+
+# promote.test-level.summary
+
+Deployment Apex testing level.
+
+# promote.test-level.description
+
+Valid values are:
+
+- NoTestRun — No tests are run. This test level applies only to deployments to development environments, such as sandbox, Developer Edition, or trial orgs. This test level is the default for development environments.
+
+- RunSpecifiedTests — Runs only the tests that you specify with the --run-tests flag. Code coverage requirements differ from the default coverage requirements when using this test level. Executed tests must comprise a minimum of 75% code coverage for each class and trigger in the deployment package. This coverage is computed for each class and trigger individually and is different than the overall coverage percentage.
+
+- RunLocalTests — All tests in your org are run, except the ones that originate from installed managed and unlocked packages. This test level is the default for production deployments that include Apex classes or triggers.
+
+- RunAllTestsInOrg — All tests in your org are run, including tests of managed packages.
+
+If you don’t specify a test level, the default behavior depends on the contents of your deployment package. For more information, see [Running Tests in a Deployment](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy_running_tests.htm) in the "Metadata API Developer Guide".

--- a/messages/deploy.pipeline.md
+++ b/messages/deploy.pipeline.md
@@ -1,0 +1,29 @@
+# summary
+
+Deploy changes from a branch to the pipeline stage’s org.
+
+# description
+
+Before you run this command, changes in the branch must be merged in the source control repository.
+
+# examples
+
+- Deploy changes in the Staging branch to the Staging environment (sandbox), if the previous stage is the bundling stage:
+
+  <%= config.bin %> <%= command.id %> --devops-center-project-name “Recruiting App” --branch-name staging --devops-center-username MyStagingSandbox --bundle-version-name 1.0
+
+- Deploy all changes in the main branch to the release environment:
+
+  <%= config.bin %> <%= command.id %> --devops-center-project-name “Recruiting App” --branch-name main --devops-center-username MyReleaseOrg --deploy-all
+
+# error.BranchNotFound
+
+Can't find any branch named %s in project %s.
+
+# error.NoTestsSpecified
+
+You must specify tests using the --tests flag if the --test-level flag is set to RunSpecifiedTests.
+
+# error.InvalidRunTests
+
+runTests can only be used with a testLevel of RunSpecifiedTests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@salesforce/plugin-template-sf",
-  "description": "A template repository for sf plugins",
+  "name": "@salesforce/plugin-devops-center",
+  "description": "The DevOps Center CLI plugin provides a command-line alternative to performing equivalent actions in the DevOps Center graphical UI",
   "version": "0.0.1",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
@@ -74,7 +74,11 @@
       "@oclif/plugin-command-snapshot",
       "@salesforce/plugin-command-reference"
     ],
-    "topics": {}
+    "topics": {
+      "deploy": {
+        "description": "Commands to deploy artifacts to an environment."
+      }
+    }
   },
   "repository": "salesforcecli/plugin-template-sf",
   "scripts": {

--- a/schemas/deploy-pipeline.json
+++ b/schemas/deploy-pipeline.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/PromotePipelineResult",
+  "definitions": {
+    "PromotePipelineResult": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": ["status"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/commands/deploy/pipeline.ts
+++ b/src/commands/deploy/pipeline.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Messages } from '@salesforce/core';
+import { SfCommand } from '@salesforce/sf-plugins-core';
+import { PromotePipelineResult, validateTestFlags } from '../../common';
+import {
+  branchName,
+  bundleVersionName,
+  deployAll,
+  devopsCenterProjectName,
+  devopsCenterUsername,
+  specificTests,
+  testLevel,
+} from '../../common/flags';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-devops-center', 'deploy.pipeline');
+
+export default class DeployPipeline extends SfCommand<PromotePipelineResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly state = 'beta';
+
+  public static flags = {
+    'branch-name': branchName,
+    'bundle-version-name': bundleVersionName,
+    'deploy-all': deployAll,
+    'devops-center-project-name': devopsCenterProjectName,
+    'devops-center-username': devopsCenterUsername,
+    tests: specificTests,
+    'test-level': testLevel(),
+  };
+
+  public async run(): Promise<PromotePipelineResult> {
+    const { flags } = await this.parse(DeployPipeline);
+    validateTestFlags(flags['test-level'], flags.tests);
+
+    return { status: 'status' };
+  }
+}

--- a/src/commands/deploy/pipeline.ts
+++ b/src/commands/deploy/pipeline.ts
@@ -27,7 +27,7 @@ export default class DeployPipeline extends SfCommand<PromotePipelineResult> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly state = 'beta';
 
-  public static flags = {
+  public static readonly flags = {
     'branch-name': branchName,
     'bundle-version-name': bundleVersionName,
     'deploy-all': deployAll,

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Messages } from '@salesforce/core';
+import { Flags } from '@oclif/core';
+import { TestLevel } from '../common';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-devops-center', 'commonFlags');
+
+export const devopsCenterProjectName = Flags.string({
+  char: 'p',
+  summary: messages.getMessage('promote.devops-center-project-name.summary'),
+  required: true,
+});
+
+export const branchName = Flags.string({
+  char: 'b',
+  summary: messages.getMessage('promote.branch-name.summary'),
+  required: true,
+});
+
+export const testLevel = Flags.custom<TestLevel>({
+  char: 'l',
+  parse: (input) => Promise.resolve(input as TestLevel),
+  options: Object.values(TestLevel),
+  description: messages.getMessage('promote.test-level.description'),
+  summary: messages.getMessage('promote.test-level.summary'),
+});
+
+export const specificTests = Flags.string({
+  char: 't',
+  multiple: true,
+  description: messages.getMessage('promote.tests.description'),
+  summary: messages.getMessage('promote.tests.summary'),
+});
+
+export const deployAll = Flags.boolean({
+  char: 'a',
+  description: messages.getMessage('promote.deploy-all.description'),
+  summary: messages.getMessage('promote.deploy-all.summary'),
+});
+
+export const devopsCenterUsername = Flags.string({
+  char: 'c',
+  summary: messages.getMessage('promote.devops-center-username.summary'),
+});
+
+export const bundleVersionName = Flags.string({
+  char: 'v',
+  summary: messages.getMessage('promote.bundle-version-name.summary'),
+  description: messages.getMessage('promote.bundle-version-name.description'),
+});

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export { PromotePipelineResult, TestLevel } from './types';
+export { validateTestFlags } from './utils';

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -5,4 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-// TODO: remove file after we have another test
+export type PromotePipelineResult = {
+  status: string;
+};
+
+export enum TestLevel {
+  NoTestRun = 'NoTestRun',
+  RunSpecifiedTests = 'RunSpecifiedTests',
+  RunLocalTests = 'RunLocalTests',
+  RunAllTestsInOrg = 'RunAllTestsInOrg',
+}

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Messages } from '@salesforce/core';
+import { Nullable } from '@salesforce/ts-types';
+import { TestLevel } from '../common';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-devops-center', 'deploy.pipeline');
+
+export function validateTestFlags(testLevel: TestLevel, tests: Nullable<string[]>): void {
+  if (testLevel === TestLevel.RunSpecifiedTests && (tests ?? []).length === 0) {
+    throw messages.createError('error.NoTestsSpecified');
+  } else if (testLevel !== TestLevel.RunSpecifiedTests && tests) {
+    throw messages.createError('error.InvalidRunTests');
+  }
+}

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -12,7 +12,7 @@ import { TestLevel } from '../common';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-devops-center', 'deploy.pipeline');
 
-export function validateTestFlags(testLevel: TestLevel, tests: Nullable<string[]>): void {
+export function validateTestFlags(testLevel: Nullable<TestLevel>, tests: Nullable<string[]>): void {
   if (testLevel === TestLevel.RunSpecifiedTests && (tests ?? []).length === 0) {
     throw messages.createError('error.NoTestsSpecified');
   } else if (testLevel !== TestLevel.RunSpecifiedTests && tests) {

--- a/test/commands/deploy/pipeline.test.ts
+++ b/test/commands/deploy/pipeline.test.ts
@@ -29,7 +29,7 @@ describe('validate flags', () => {
     .stderr()
     .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '-l=RunSpecifiedTests'])
     .it(
-      'runs deploy pipeline with test level RunSpecifiedTests but does not indicates specifi test with flag -t',
+      'runs deploy pipeline with test level RunSpecifiedTests but does not indicate specific tests with flag -t',
       (ctx) => {
         expect(ctx.stderr).to.contain(
           'You must specify tests using the --tests flag if the --test-level flag is set to RunSpecifiedTests.'
@@ -42,9 +42,17 @@ describe('validate flags', () => {
     .stderr()
     .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '-l=RunLocalTests', '-t=DummyTestClass'])
     .it(
-      'runs deploy pipeline with test level RunSpecifiedTests but does not indicates specifi test with flag -t',
+      'runs deploy pipeline indicating specific tests to run but with test level other than RunSpecifiedTests',
       (ctx) => {
         expect(ctx.stderr).to.contain('runTests can only be used with a testLevel of RunSpecifiedTests.');
       }
     );
+
+  test
+    .stdout()
+    .stderr()
+    .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '-l=RunSpecifiedTests', '-t=DummyTestClass'])
+    .it('runs deploy pipeline with the correct flags and validation pass', (ctx) => {
+      expect(ctx.stderr).to.equal('');
+    });
 });

--- a/test/commands/deploy/pipeline.test.ts
+++ b/test/commands/deploy/pipeline.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, test } from '@oclif/test';
+
+describe('validate flags', () => {
+  test
+    .stdout()
+    .stderr()
+    .command(['deploy:pipeline', '--branch-name=test'])
+    .it('runs deploy pipeline with no provided project name', (ctx) => {
+      expect(ctx.stderr).to.contain('Missing required flag devops-center-project-name');
+    });
+
+  test
+    .stdout()
+    .stderr()
+    .command(['deploy:pipeline', '--devops-center-project-name=test'])
+    .it('runs deploy pipeline with no provided branch name', (ctx) => {
+      expect(ctx.stderr).to.contain('Missing required flag branch-name');
+    });
+
+  test
+    .stdout()
+    .stderr()
+    .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '-l=RunSpecifiedTests'])
+    .it(
+      'runs deploy pipeline with test level RunSpecifiedTests but does not indicates specifi test with flag -t',
+      (ctx) => {
+        expect(ctx.stderr).to.contain(
+          'You must specify tests using the --tests flag if the --test-level flag is set to RunSpecifiedTests.'
+        );
+      }
+    );
+
+  test
+    .stdout()
+    .stderr()
+    .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '-l=RunLocalTests', '-t=DummyTestClass'])
+    .it(
+      'runs deploy pipeline with test level RunSpecifiedTests but does not indicates specifi test with flag -t',
+      (ctx) => {
+        expect(ctx.stderr).to.contain('runTests can only be used with a testLevel of RunSpecifiedTests.');
+      }
+    );
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@salesforce/dev-config/tsconfig-test",
   "include": ["./**/*.ts"],
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strictNullChecks": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@salesforce/dev-config/tsconfig",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "strictNullChecks": true
   },
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
### What does this PR do?
Adds new command **sf deploy pipeline**. Only includes the required and optional flags as well as its validations.

### What issues does this PR fix or reference?

[W-11912468](https://gus.lightning.force.com/lightning/a07EE000018q8J3YAI)
[W-11991482](https://gus.lightning.force.com/lightning/a07EE00001BF8ADYA1)
[W-11991498](https://gus.lightning.force.com/lightning/a07EE00001BFISPYA5)