### PR TITLE
Add --target-devops-center config variable

### DIFF
--- a/messages/commonFlags.md
+++ b/messages/commonFlags.md
@@ -51,3 +51,11 @@ Valid values are:
 - RunAllTestsInOrg — All tests in your org are run, including tests of managed packages.
 
 If you don’t specify a test level, the default behavior depends on the contents of your deployment package. For more information, see [Running Tests in a Deployment](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy_running_tests.htm) in the "Metadata API Developer Guide".
+
+# flags.targetDoceOrg.summary
+
+Username or alias of the target org.
+
+# errors.NoDefaultDoceEnv
+
+You must specify the DevOps Center org username by indicating the -c flag on the command line or by setting the --target-devops-center configuration variable.

--- a/messages/config.md
+++ b/messages/config.md
@@ -1,0 +1,3 @@
+# target-devops-center
+
+Username or alias of the DevOps Center org.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "oclif": {
     "commands": "./lib/commands",
     "bin": "sf",
+    "configMeta": "./lib/configMeta",
     "topicSeparator": " ",
     "devPlugins": [
       "@oclif/plugin-help",

--- a/src/commands/deploy/pipeline.ts
+++ b/src/commands/deploy/pipeline.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -13,7 +13,7 @@ import {
   bundleVersionName,
   deployAll,
   devopsCenterProjectName,
-  devopsCenterUsername,
+  requiredDoceOrgFlag,
   specificTests,
   testLevel,
 } from '../../common/flags';
@@ -32,7 +32,7 @@ export default class DeployPipeline extends SfCommand<PromotePipelineResult> {
     'bundle-version-name': bundleVersionName,
     'deploy-all': deployAll,
     'devops-center-project-name': devopsCenterProjectName,
-    'devops-center-username': devopsCenterUsername,
+    'devops-center-username': requiredDoceOrgFlag(),
     tests: specificTests,
     'test-level': testLevel(),
   };

--- a/src/commands/deploy/pipeline.ts
+++ b/src/commands/deploy/pipeline.ts
@@ -21,6 +21,9 @@ import {
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-devops-center', 'deploy.pipeline');
 
+/**
+ * Contains the logic to execute the sf deploy pipeline command.
+ */
 export default class DeployPipeline extends SfCommand<PromotePipelineResult> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
@@ -41,6 +44,7 @@ export default class DeployPipeline extends SfCommand<PromotePipelineResult> {
     const { flags } = await this.parse(DeployPipeline);
     validateTestFlags(flags['test-level'], flags.tests);
 
+    // hardcoded value so it compiles until main logic is implemented
     return { status: 'status' };
   }
 }

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -26,6 +26,10 @@ export const branchName = Flags.string({
   required: true,
 });
 
+/**
+ * Custom flag for the test level.
+ * Validates that the passed in value is a valid test level.
+ */
 export const testLevel = OclifFlags.custom<TestLevel>({
   char: 'l',
   parse: (input) => Promise.resolve(input as TestLevel),
@@ -53,6 +57,11 @@ export const bundleVersionName = Flags.string({
   description: messages.getMessage('promote.bundle-version-name.description'),
 });
 
+/**
+ * Custom flag for the target devops center org.
+ * Makes this flag required and validates that passed in alias/username corresponds to an authenticated org.
+ * If no value is passed in, then it looks for the alias/username set in the --target-devops-center config variable.
+ */
 export const requiredDoceOrgFlag = OclifFlags.custom({
   char: 'c',
   summary: messages.getMessage('flags.targetDoceOrg.summary'),
@@ -61,6 +70,12 @@ export const requiredDoceOrgFlag = OclifFlags.custom({
   defaultHelp: async () => (await getOrgOrThrow())?.getUsername(),
 });
 
+/**
+ *
+ * @param input alias/username of an org
+ * @returns instance of an Org that correspons to the alias/username passed in
+ * or to the alias/username set in --target-devops-center config variable.
+ */
 const getOrgOrThrow = async (input?: string): Promise<Org> => {
   const aggregator = await ConfigAggregator.create({ customConfigMeta: ConfigMeta });
   let org: Org;

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -5,9 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Messages } from '@salesforce/core';
-import { Flags } from '@oclif/core';
+import { ConfigAggregator, Messages, Org } from '@salesforce/core';
+import { Flags } from '@salesforce/sf-plugins-core';
+import { Flags as OclifFlags } from '@oclif/core';
 import { TestLevel } from '../common';
+import ConfigMeta, { ConfigVars } from '../configMeta';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-devops-center', 'commonFlags');
@@ -24,7 +26,7 @@ export const branchName = Flags.string({
   required: true,
 });
 
-export const testLevel = Flags.custom<TestLevel>({
+export const testLevel = OclifFlags.custom<TestLevel>({
   char: 'l',
   parse: (input) => Promise.resolve(input as TestLevel),
   options: Object.values(TestLevel),
@@ -45,13 +47,33 @@ export const deployAll = Flags.boolean({
   summary: messages.getMessage('promote.deploy-all.summary'),
 });
 
-export const devopsCenterUsername = Flags.string({
-  char: 'c',
-  summary: messages.getMessage('promote.devops-center-username.summary'),
-});
-
 export const bundleVersionName = Flags.string({
   char: 'v',
   summary: messages.getMessage('promote.bundle-version-name.summary'),
   description: messages.getMessage('promote.bundle-version-name.description'),
 });
+
+export const requiredDoceOrgFlag = OclifFlags.custom({
+  char: 'c',
+  summary: messages.getMessage('flags.targetDoceOrg.summary'),
+  parse: async (input: string | undefined) => getOrgOrThrow(input),
+  default: async () => getOrgOrThrow(),
+  defaultHelp: async () => (await getOrgOrThrow())?.getUsername(),
+});
+
+const getOrgOrThrow = async (input?: string): Promise<Org> => {
+  const aggregator = await ConfigAggregator.create({ customConfigMeta: ConfigMeta });
+  let org: Org;
+  try {
+    org = await Org.create({
+      aliasOrUsername: input ? input : aggregator.getInfo(ConfigVars.TARGET_DEVOPS_CENTER)?.value?.toString(),
+    });
+  } catch (e) {
+    if (!input) {
+      throw messages.createError('errors.NoDefaultDoceEnv');
+    } else {
+      throw e;
+    }
+  }
+  return org;
+};

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -12,6 +12,13 @@ import { TestLevel } from '../common';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-devops-center', 'deploy.pipeline');
 
+/**
+ * @description validates the following:
+ * - if RunSpecifiedTests is selected, then it needs to indicate tests to run.
+ * - if other than RunSpecifiedTests is selected, then it can't indicate tests to run.
+ * @param testLevel selected test level
+ * @param tests specific tests to run
+ */
 export function validateTestFlags(testLevel: Nullable<TestLevel>, tests: Nullable<string[]>): void {
   if (testLevel === TestLevel.RunSpecifiedTests && (tests ?? []).length === 0) {
     throw messages.createError('error.NoTestsSpecified');

--- a/src/configMeta.ts
+++ b/src/configMeta.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Messages } from '@salesforce/core';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-devops-center', 'config');
+
+export enum ConfigVars {
+  TARGET_DEVOPS_CENTER = 'target-devops-center',
+}
+
+export default [
+  {
+    key: ConfigVars.TARGET_DEVOPS_CENTER,
+    description: messages.getMessage(ConfigVars.TARGET_DEVOPS_CENTER),
+    hidden: false,
+  },
+];

--- a/src/configMeta.ts
+++ b/src/configMeta.ts
@@ -14,6 +14,10 @@ export enum ConfigVars {
   TARGET_DEVOPS_CENTER = 'target-devops-center',
 }
 
+/**
+ * Creates a configuration variable called --target-devops-center.
+ * Once set, it acts as the default target devops center org for the commands in this plugin.
+ */
 export default [
   {
     key: ConfigVars.TARGET_DEVOPS_CENTER,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2021, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
-
-export = {};

--- a/test/commands/deploy/pipeline.test.ts
+++ b/test/commands/deploy/pipeline.test.ts
@@ -1,13 +1,36 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
 import { expect, test } from '@oclif/test';
+import * as sinon from 'sinon';
+import { Org } from '@salesforce/core';
+
+const DOCE_ORG = {
+  id: '1',
+  getOrgId() {
+    return '1';
+  },
+  getAlias() {
+    return ['doceOrg'];
+  },
+};
 
 describe('validate flags', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sandbox.stub(Org, 'create' as any).returns(DOCE_ORG);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
   test
     .stdout()
     .stderr()

--- a/test/common/flags.test.ts
+++ b/test/common/flags.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { assert, expect } from 'chai';
+import * as sinon from 'sinon';
+import { Parser } from '@oclif/core';
+import { ConfigAggregator, Org } from '@salesforce/core';
+import { ConfigVars } from '../../src/configMeta';
+import { requiredDoceOrgFlag } from '../../src/common/flags';
+
+const TARGET_DEVOPS_CENTER_ALIAS = 'target-devops-center';
+const MOCK_TARGET_DEVOPS_CENTER = {
+  id: '1',
+  getOrgId() {
+    return '1';
+  },
+  getAlias(): string {
+    return TARGET_DEVOPS_CENTER_ALIAS;
+  },
+};
+const MOCK_DOCE_ORG = {
+  id: '2',
+  getOrgId() {
+    return '2';
+  },
+  getAlias() {
+    return 'doce-org';
+  },
+};
+
+describe('requiredDoceOrgFlag', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('returns the org that corresponds to the alias set in --target-devops-center config variable', async () => {
+    sandbox
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .stub(Org, 'create' as any)
+      .withArgs({ aliasOrUsername: MOCK_TARGET_DEVOPS_CENTER.getAlias() })
+      .returns(MOCK_TARGET_DEVOPS_CENTER)
+      .withArgs({ aliasOrUsername: MOCK_DOCE_ORG.getAlias() })
+      .returns(MOCK_DOCE_ORG);
+
+    // mock config var --target-devops-center
+    sandbox.stub(ConfigAggregator.prototype, 'getInfo').returns({
+      value: TARGET_DEVOPS_CENTER_ALIAS,
+      key: ConfigVars.TARGET_DEVOPS_CENTER,
+      isLocal: () => false,
+      isGlobal: () => true,
+      isEnvVar: () => false,
+    });
+
+    // value for the flag is not provided
+    const out = await Parser.parse(['--requiredDoceOrg='], {
+      flags: { requiredDoceOrg: requiredDoceOrgFlag() },
+    });
+
+    expect(out.flags.requiredDoceOrg).to.deep.equal(MOCK_TARGET_DEVOPS_CENTER);
+  });
+
+  it('returns the org that correpsonds to the alias provided and that overides the --target-devops-center org', async () => {
+    sandbox
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .stub(Org, 'create' as any)
+      .withArgs({ aliasOrUsername: MOCK_TARGET_DEVOPS_CENTER.getAlias() })
+      .returns(MOCK_TARGET_DEVOPS_CENTER)
+      .withArgs({ aliasOrUsername: MOCK_DOCE_ORG.getAlias() })
+      .returns(MOCK_DOCE_ORG);
+
+    // mock config var --target-devops-center
+    sandbox.stub(ConfigAggregator.prototype, 'getInfo').returns({
+      value: TARGET_DEVOPS_CENTER_ALIAS,
+      key: ConfigVars.TARGET_DEVOPS_CENTER,
+      isLocal: () => false,
+      isGlobal: () => true,
+      isEnvVar: () => false,
+    });
+
+    const out = await Parser.parse([`--requiredDoceOrg=${MOCK_DOCE_ORG.getAlias()}`], {
+      flags: { requiredDoceOrg: requiredDoceOrgFlag() },
+    });
+
+    expect(out.flags.requiredDoceOrg).to.deep.equal(MOCK_DOCE_ORG);
+  });
+
+  it('fails when no value is provided and the --target-devops-center config var is not set', async () => {
+    sandbox.stub(ConfigAggregator.prototype, 'getInfo').returns({
+      value: null,
+      key: ConfigVars.TARGET_DEVOPS_CENTER,
+      isLocal: () => false,
+      isGlobal: () => true,
+      isEnvVar: () => false,
+    });
+    try {
+      await Parser.parse(['--requiredDoceOrg='], {
+        flags: { requiredDoceOrg: requiredDoceOrgFlag() },
+      });
+      assert.fail('This should have failed');
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(err.message).to.include(
+        'You must specify the DevOps Center org username by indicating the -c flag on the command line or by setting the --target-devops-center configuration variable.'
+      );
+    }
+  });
+
+  it('fails when an invalid alias is provided and the --target-devops-center config var is not set', async () => {
+    const invalidAlias = 'invalidAlias';
+    sandbox.stub(ConfigAggregator.prototype, 'getInfo').returns({
+      value: null,
+      key: ConfigVars.TARGET_DEVOPS_CENTER,
+      isLocal: () => false,
+      isGlobal: () => true,
+      isEnvVar: () => false,
+    });
+    try {
+      await Parser.parse([`--requiredDoceOrg=${invalidAlias}`], {
+        flags: { requiredDoceOrg: requiredDoceOrgFlag() },
+      });
+      assert.fail('This should have failed');
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(err.message).to.include(`No authorization information found for ${invalidAlias}`);
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?

- Adds new configuration variable called --target-devops-center.
- Makes --devops-center-username flag required.

### What issues does this PR fix or reference?

[W-11940232](https://gus.lightning.force.com/a07EE000019NR6aYAG)

### Functionality Before

--devops-center-username was optional and no validations were enforced on it.

### Functionality After

We make sure there is a target devops center org. It could be set as a default org using the configuration variable or the user can provide one using the -c flag.  
