### PR TITLE
Better error message when the config variable does not correspond with an authenticated org 

### DIFF
--- a/messages/commonFlags.md
+++ b/messages/commonFlags.md
@@ -66,4 +66,4 @@ Username or alias of the target org.
 
 # errors.NoDefaultDoceEnv
 
-You must specify the DevOps Center org username by indicating the -c flag on the command line or by setting the --target-devops-center configuration variable.
+You must specify the DevOps Center org username by indicating the -c flag on the command line or by setting the target-devops-center configuration variable.

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -83,17 +83,10 @@ export const requiredDoceOrgFlag = OclifFlags.custom({
  */
 const getOrgOrThrow = async (input?: string): Promise<Org> => {
   const aggregator = await ConfigAggregator.create({ customConfigMeta: ConfigMeta });
-  let org: Org;
-  try {
-    org = await Org.create({
-      aliasOrUsername: input ? input : aggregator.getInfo(ConfigVars.TARGET_DEVOPS_CENTER)?.value?.toString(),
-    });
-  } catch (e) {
-    if (!input) {
-      throw messages.createError('errors.NoDefaultDoceEnv');
-    } else {
-      throw e;
-    }
+  const alias = input ? input : aggregator.getInfo(ConfigVars.TARGET_DEVOPS_CENTER)?.value?.toString();
+  if (!alias) {
+    throw messages.createError('errors.NoDefaultDoceEnv');
   }
+  const org: Org = await Org.create({ aliasOrUsername: alias });
   return org;
 };

--- a/test/commands/deploy/pipeline.test.ts
+++ b/test/commands/deploy/pipeline.test.ts
@@ -8,7 +8,8 @@
 import { expect, test } from '@oclif/test';
 import { TestContext } from '@salesforce/core/lib/testSetup';
 import * as sinon from 'sinon';
-import { Org } from '@salesforce/core';
+import { ConfigAggregator, Org } from '@salesforce/core';
+import { ConfigVars } from '../../../src/configMeta';
 import { PromoteCommand } from '../../../src/common/abstractPromote';
 import { DeployPipelineCache } from '../../../src/common/deployPipelineCache';
 
@@ -30,6 +31,13 @@ describe('deploy pipeline', () => {
     sandbox = sinon.createSandbox();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sandbox.stub(Org, 'create' as any).returns(DOCE_ORG);
+    sandbox.stub(ConfigAggregator.prototype, 'getInfo').returns({
+      value: 'TARGET_DEVOPS_CENTER_ALIAS',
+      key: ConfigVars.TARGET_DEVOPS_CENTER,
+      isLocal: () => false,
+      isGlobal: () => true,
+      isEnvVar: () => false,
+    });
   });
 
   afterEach(() => {
@@ -121,7 +129,7 @@ describe('deploy pipeline', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         executeCommandStub = sandbox.stub(PromoteCommand.prototype, 'executePromotion' as any);
       })
-      .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '-c=doceOrg', '--async'])
+      .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '--async'])
       .it('cache the aorId when running deploy pipeline with the async flag', async () => {
         const cache = await DeployPipelineCache.create();
         const key = cache.resolveLatest();

--- a/test/commands/deploy/pipeline.test.ts
+++ b/test/commands/deploy/pipeline.test.ts
@@ -117,7 +117,11 @@ describe('deploy pipeline', () => {
     test
       .stdout()
       .stderr()
-      .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '--async'])
+      .do(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        executeCommandStub = sandbox.stub(PromoteCommand.prototype, 'executePromotion' as any);
+      })
+      .command(['deploy:pipeline', '-p=testProject', '-b=testBranch', '-c=doceOrg', '--async'])
       .it('cache the aorId when running deploy pipeline with the async flag', async () => {
         const cache = await DeployPipelineCache.create();
         const key = cache.resolveLatest();

--- a/test/common/flags.test.ts
+++ b/test/common/flags.test.ts
@@ -134,4 +134,24 @@ describe('requiredDoceOrgFlag', () => {
       expect(err.message).to.include(`No authorization information found for ${invalidAlias}`);
     }
   });
+
+  it('fails when no alias is provided and the --target-devops-center config var is set but invalid', async () => {
+    const invalidTargetDevopsCenter = 'invalid-target-devops-center';
+    sandbox.stub(ConfigAggregator.prototype, 'getInfo').returns({
+      value: 'invalid-target-devops-center',
+      key: ConfigVars.TARGET_DEVOPS_CENTER,
+      isLocal: () => false,
+      isGlobal: () => true,
+      isEnvVar: () => false,
+    });
+    try {
+      await Parser.parse(['--requiredDoceOrg='], {
+        flags: { requiredDoceOrg: requiredDoceOrgFlag() },
+      });
+      assert.fail('This should have failed');
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(err.message).to.include(`No authorization information found for ${invalidTargetDevopsCenter}`);
+    }
+  });
 });

--- a/test/common/flags.test.ts
+++ b/test/common/flags.test.ts
@@ -110,7 +110,7 @@ describe('requiredDoceOrgFlag', () => {
     } catch (err) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(err.message).to.include(
-        'You must specify the DevOps Center org username by indicating the -c flag on the command line or by setting the --target-devops-center configuration variable.'
+        'You must specify the DevOps Center org username by indicating the -c flag on the command line or by setting the target-devops-center configuration variable.'
       );
     }
   });


### PR DESCRIPTION
### What does this PR do?
Update the validation for requiredDoceOrg flag so it prints a better error message when the username/alias stored in the -target-devops-center config variable does not correspond with an authenticated org.

### What issues does this PR fix or reference?

[W-11940232](https://gus.lightning.force.com/a07EE000019NR6aYAG)

### Functionality Before

Error message says that no target org was provided.

### Functionality After

Error message says that the provided target org is not authenticated.
