### PR TITLE
fix: prevent defaultHelp method to throw when there is no target-devops-center value set

### DIFF
--- a/src/common/base/abstractPromote.ts
+++ b/src/common/base/abstractPromote.ts
@@ -185,7 +185,7 @@ export abstract class PromoteCommand<T extends typeof SfCommand> extends SfComma
    * @returns
    */
   protected catch(error: Error | SfError): Promise<SfCommand.Error> {
-    if (error.name.includes('GenericTimeoutError')) {
+    if (error.name?.includes('GenericTimeoutError')) {
       const err = messages.createError('error.ClientTimeout', [
         this.config.bin,
         this.id?.split(':').slice(0, -1).join(' '),

--- a/src/common/base/abstractResume.ts
+++ b/src/common/base/abstractResume.ts
@@ -105,7 +105,7 @@ export abstract class ResumeCommand<T extends typeof SfCommand> extends SfComman
    * @returns
    */
   protected catch(error: Error | SfError): Promise<SfCommand.Error> {
-    if (error.name.includes('GenericTimeoutError')) {
+    if (error.name?.includes('GenericTimeoutError')) {
       const err = messages.createError('error.ClientTimeout', [
         this.config.bin,
         this.id?.split(':').slice(0, -1).join(' '),

--- a/test/common/flags.test.ts
+++ b/test/common/flags.test.ts
@@ -11,7 +11,13 @@ import { Parser } from '@oclif/core';
 import { ConfigAggregator, Org } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import { ConfigVars } from '../../src/configMeta';
-import { requiredDoceOrgFlag, wait, verbose, concise } from '../../src/common/flags/flags';
+import {
+  requiredDoceOrgFlag,
+  wait,
+  verbose,
+  concise,
+  getDefaultDevopsCenterUsernameAlias,
+} from '../../src/common/flags/flags';
 import { async } from '../../src/common/flags/promote/promoteFlags';
 
 const TARGET_DEVOPS_CENTER_ALIAS = 'target-devops-center';
@@ -155,6 +161,30 @@ describe('requiredDoceOrgFlag', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(err.message).to.include(`No authorization information found for ${invalidTargetDevopsCenter}`);
     }
+  });
+
+  it('returns the value of the target-devops-center config variable', async () => {
+    sandbox.stub(ConfigAggregator.prototype, 'getInfo').returns({
+      value: TARGET_DEVOPS_CENTER_ALIAS,
+      key: ConfigVars.TARGET_DEVOPS_CENTER,
+      isLocal: () => false,
+      isGlobal: () => true,
+      isEnvVar: () => false,
+    });
+    const defaultDoceAlias = await getDefaultDevopsCenterUsernameAlias();
+    expect(defaultDoceAlias).to.equal(TARGET_DEVOPS_CENTER_ALIAS);
+  });
+
+  it('returns undefined when there is not a target-devops-center config variable', async () => {
+    sandbox.stub(ConfigAggregator.prototype, 'getInfo').returns({
+      value: null,
+      key: ConfigVars.TARGET_DEVOPS_CENTER,
+      isLocal: () => false,
+      isGlobal: () => true,
+      isEnvVar: () => false,
+    });
+    const defaultDoceAlias = await getDefaultDevopsCenterUsernameAlias();
+    expect(defaultDoceAlias).to.equal(undefined);
   });
 });
 


### PR DESCRIPTION
### What does this PR do?
Change the callback function on requiredDoceOrgFlag.defaultHelp. The new callback does not throw if it can't find a target Devops Center org.

### What issues does this PR fix or reference?

[W-12738813](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NfaZ7YAJ/view)

### Functionality Before

Running any command without having a value in target-devops-center config variable fails with error  _"You must specify the DevOps Center org username by indicating the -c flag on the command line or by setting the target-devops-center configuration variable"_ even when the user does provide -c flag.

### Functionality After

Commands correctly detect the provided -c flag.
