### PR TITLE
fix: add verbosity flags to resume command

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,13 +199,15 @@ Resume watching a pipeline deploy operation.
 
 ```
   USAGE
-    $ sf project deploy pipeline resume [--json] [-c <value>] [-i <value>] [-r] [-w <value>]
+    $ sf project deploy pipeline resume [--json] [-c <value>] [-i <value>] [-r] [-w <value>] [--concise | --verbose]
 
   FLAGS
     -c, --devops-center-username=<value>  Username or alias of the DevOps Center org.
     -i, --job-id=<value>                  Job ID of the pipeline deploy operation you want to resume.
     -r, --use-most-recent                 Use the job ID of the most recent deploy operation.
     -w, --wait=<minutes>                  Number of minutes to wait for command to complete and display results.
+    --concise                             Show concise output of the deploy result.
+    --verbose                             Show verbose output of the deploy result.
 
   GLOBAL FLAGS
     --json  Format output as json.

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -8,7 +8,7 @@
   {
     "command": "project:deploy:pipeline:resume",
     "plugin": "@salesforce/plugin-devops-center",
-    "flags": ["devops-center-username", "job-id", "json", "use-most-recent", "wait"],
+    "flags": ["concise", "devops-center-username", "job-id", "json", "use-most-recent", "verbose", "wait"],
     "alias": []
   },
   {

--- a/src/common/base/abstractPromote.ts
+++ b/src/common/base/abstractPromote.ts
@@ -113,7 +113,7 @@ export abstract class PromoteCommand<T extends typeof SfCommand> extends SfComma
     );
     await doceMonitor.monitor();
     if (this.outputService.getStatus() === AsyncOperationStatus.Completed) {
-      await this.outputService.displayEndResults();
+      this.outputService.displayEndResults();
     }
 
     // get final state of the async job

--- a/src/common/outputService/outputServiceFactory.ts
+++ b/src/common/outputService/outputServiceFactory.ts
@@ -9,9 +9,10 @@
 
 import { Connection } from '@salesforce/core';
 import { SfCommand } from '@salesforce/sf-plugins-core';
-import * as Promote from '../base/abstractPromote';
+import { Flags as PromoteFlags } from '../base/abstractPromote';
+import { Flags as ReportFlags } from '../base/abstractReportOnPromote';
+import { Flags as ResumeFlags } from '../base/abstractResume';
 import { DeploymentResult } from '../types';
-import { Flags } from '../base/abstractReportOnPromote';
 import { DeployCommandOutputService } from './deployCommandOutputService';
 import { PromoteReportOutputService } from './reportOutputService';
 import { ResumeCommandOutputService } from './resumeCommandOutputService';
@@ -25,22 +26,26 @@ export class OutputServiceFactory {
   /**
    * Create a service to print the deployment info.
    */
-  public forDeployment(flags: Promote.Flags<typeof SfCommand>, con: Connection): DeployCommandOutputService {
+  public forDeployment(flags: PromoteFlags<typeof SfCommand>, con: Connection): DeployCommandOutputService {
     return new DeployCommandOutputService(flags, con);
   }
 
   /**
    * Create a service to print the resume info.
    */
-  public forResume(operationType: string): ResumeCommandOutputService {
-    return new ResumeCommandOutputService(operationType);
+  public forResume(
+    flags: ResumeFlags<typeof SfCommand>,
+    operationType: string,
+    con: Connection
+  ): ResumeCommandOutputService {
+    return new ResumeCommandOutputService(flags, operationType, con);
   }
 
   /**
    * Create a service to print the report info.
    */
   public forPromotionReport(
-    flags: Flags<typeof SfCommand>,
+    flags: ReportFlags<typeof SfCommand>,
     operationResult: DeploymentResult,
     operationName: string
   ): PromoteReportOutputService {

--- a/src/common/outputService/promoteOutputService.ts
+++ b/src/common/outputService/promoteOutputService.ts
@@ -6,9 +6,6 @@
  */
 
 import { Connection, Messages } from '@salesforce/core';
-import { DeployComponentsTable } from '../outputColumns';
-import { DeployComponent } from '../types';
-import { getFormattedDeployComponentsByAyncOpId } from '../utils';
 import { AorOutputFlags } from './aorOutputService';
 import { DeploySummaryBuilder } from './deploySummaryBuilder';
 import { OutputService } from './outputService';
@@ -28,9 +25,7 @@ export type PromoteOutputFlags = {
  *
  * @author JuanStenghele-sf
  */
-export interface PromoteOutputService extends ResumeOutputService {
-  displayEndResults(): Promise<void>;
-}
+export interface PromoteOutputService extends ResumeOutputService {}
 
 /**
  * Abstract class that implements PromoteOutputService interface
@@ -42,7 +37,6 @@ export abstract class AbstractPromoteOutputService
   implements PromoteOutputService
 {
   private summaryBuilder: DeploySummaryBuilder;
-  private con: Connection;
 
   public constructor(flags: PromoteOutputFlags, summaryBuilder: DeploySummaryBuilder, con: Connection) {
     super(flags, '');
@@ -68,16 +62,6 @@ export abstract class AbstractPromoteOutputService
       // We print the summary
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await deploySummaryOutputService.printOpSummary();
-    }
-  }
-
-  /**
-   * This method will print a table of the deployed components for the current AOR
-   */
-  public async displayEndResults(): Promise<void> {
-    if (this.flags.verbose) {
-      const components: DeployComponent[] = await getFormattedDeployComponentsByAyncOpId(this.con, this.aorId);
-      this.displayTable(components, DeployComponentsTable.title, DeployComponentsTable.columns);
     }
   }
 }

--- a/src/common/outputService/resumeCommandOutputService.ts
+++ b/src/common/outputService/resumeCommandOutputService.ts
@@ -7,9 +7,11 @@
 
 /* eslint-disable no-console, @typescript-eslint/require-await */
 
-import { Messages } from '@salesforce/core';
-import { AbstractAorOutputService, AorOutputFlags } from './aorOutputService';
-import { ResumeOutputService } from './resumeOutputService';
+import { Connection, Messages } from '@salesforce/core';
+import { SfCommand } from '@salesforce/sf-plugins-core';
+import { Flags } from '../base/abstractResume';
+import { AorOutputFlags } from './aorOutputService';
+import { AbstractResumeOutputService } from './resumeOutputService';
 
 Messages.importMessagesDirectory(__dirname);
 const output = Messages.loadMessages('@salesforce/plugin-devops-center', 'resume.output');
@@ -19,14 +21,18 @@ const output = Messages.loadMessages('@salesforce/plugin-devops-center', 'resume
  *
  * @author JuanStenghele-sf
  */
-export class ResumeCommandOutputService
-  extends AbstractAorOutputService<AorOutputFlags>
-  implements ResumeOutputService
-{
+export class ResumeCommandOutputService extends AbstractResumeOutputService<AorOutputFlags> {
   private operationType: string;
 
-  public constructor(operationType: string) {
-    super({}, '');
+  public constructor(flags: Flags<typeof SfCommand>, operationType: string, con: Connection) {
+    super(
+      {
+        concise: flags['concise'],
+        verbose: flags['verbose'],
+      },
+      ''
+    );
+    this.con = con;
     this.operationType = operationType;
   }
 

--- a/src/common/outputService/resumeOutputService.ts
+++ b/src/common/outputService/resumeOutputService.ts
@@ -5,6 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { Connection } from '@salesforce/core';
+import { DeployComponentsTable } from '../outputColumns';
+import { DeployComponent } from '../types';
+import { getFormattedDeployComponentsByAyncOpId } from '../utils';
 import { AorOutputService, AorOutputFlags, AbstractAorOutputService } from './aorOutputService';
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
@@ -14,7 +18,9 @@ import { AorOutputService, AorOutputFlags, AbstractAorOutputService } from './ao
  *
  * @author JuanStenghele-sf
  */
-export interface ResumeOutputService extends AorOutputService {}
+export interface ResumeOutputService extends AorOutputService {
+  displayEndResults(): void;
+}
 
 /**
  * Abstract class that implements ResumeOutputService interface
@@ -23,4 +29,17 @@ export interface ResumeOutputService extends AorOutputService {}
  */
 export abstract class AbstractResumeOutputService<T extends AorOutputFlags>
   extends AbstractAorOutputService<T>
-  implements ResumeOutputService {}
+  implements ResumeOutputService
+{
+  protected con: Connection;
+
+  /**
+   * This method will print a table of the deployed components for the current AOR
+   */
+  public async displayEndResults(): Promise<void> {
+    if (this.flags.verbose) {
+      const components: DeployComponent[] = await getFormattedDeployComponentsByAyncOpId(this.con, this.aorId);
+      this.displayTable(components, DeployComponentsTable.title, DeployComponentsTable.columns);
+    }
+  }
+}

--- a/test/commands/project/deploy/pipeline/resume.test.ts
+++ b/test/commands/project/deploy/pipeline/resume.test.ts
@@ -205,7 +205,7 @@ describe('project deploy pipeline resume', () => {
         stubDisplayEndResults = sandbox.stub(ResumeCommandOutputService.prototype, 'displayEndResults');
       })
       .command(['project deploy pipeline resume', `-i=${mockAorId}`, '--verbose'])
-      .it('prints output for verbose flag correctly', () => {
+      .it('calls displayEndResults when deployment is completed', () => {
         // verify we printed the end results message
         expect(stubDisplayEndResults.called).to.equal(true);
       });

--- a/test/common/outputService/resumeCommandOutputService.test.ts
+++ b/test/common/outputService/resumeCommandOutputService.test.ts
@@ -106,6 +106,32 @@ describe('resume output', () => {
     expect(ctx.stdout).to.not.contain('=== Deployed Source');
   });
 
+  test.stdout().it('does not prints the deployed components table when concise flag is provided', async (ctx) => {
+    const deployedComponents: DeployComponent[] = [
+      {
+        sf_devops__Source_Component__c: 'ApexClass:Foo',
+        sf_devops__Operation__c: 'add',
+        sf_devops__File_Path__c: 'path',
+        Type: 'ApexClass',
+        Name: 'Foo',
+      },
+      {
+        sf_devops__Source_Component__c: 'ApexClass:Bar',
+        sf_devops__Operation__c: 'add',
+        sf_devops__File_Path__c: 'path',
+        Type: 'ApexClass',
+        Name: 'Bar',
+      },
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sandbox.stub(Utils, 'getFormattedDeployComponentsByAyncOpId').resolves(deployedComponents);
+
+    outputService = getOutputService(true, false);
+    await outputService.displayEndResults();
+    expect(ctx.stdout).to.not.contain('=== Deployed Source');
+  });
+
   function getOutputService(conciseFlag: boolean, verboseFlag: boolean): ResumeCommandOutputService {
     return new ResumeCommandOutputService(
       buildResumeFlags(conciseFlag, verboseFlag),

--- a/test/common/outputService/resumeCommandOutputService.test.ts
+++ b/test/common/outputService/resumeCommandOutputService.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable camelcase */
+import * as sinon from 'sinon';
+import { expect, test } from '@oclif/test';
+import { SfCommand } from '@salesforce/sf-plugins-core';
+import { Connection } from '@salesforce/core';
+import { Duration } from '@salesforce/kit';
+import { ResumeCommandOutputService } from '../../../src/common/outputService/resumeCommandOutputService';
+import { Flags as ResumeFlags } from '../../../src/common/base/abstractResume';
+import { DeployComponent } from '../../../src/common';
+import * as Utils from '../../../src/common/utils';
+import vacuum from '../../helpers/vacuum';
+
+const TEST_OPERATION_TYPE = 'test operation type';
+
+describe('resume output', () => {
+  let sandbox: sinon.SinonSandbox;
+  let outputService: ResumeCommandOutputService;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  test.stdout().it('prints the operation summary correctly', async (ctx) => {
+    outputService = getOutputService(false, false);
+    outputService.printOpSummary();
+    expect(ctx.stdout).to.contain('*** Resuming test operation type ***');
+  });
+
+  test.stdout().it('prints the AOR Id correctly', async (ctx) => {
+    outputService = getOutputService(false, false);
+    const mockId = 'ABC';
+    outputService.setAorId(mockId);
+    outputService.printAorId();
+    expect(ctx.stdout).to.contain('Job ID: ABC');
+  });
+
+  test.stdout().it('prints the deployed components table when verbose flag is provided', async (ctx) => {
+    const deployedComponents: DeployComponent[] = [
+      {
+        sf_devops__Source_Component__c: 'ApexClass:Foo',
+        sf_devops__Operation__c: 'add',
+        sf_devops__File_Path__c: 'path',
+        Type: 'ApexClass',
+        Name: 'Foo',
+      },
+      {
+        sf_devops__Source_Component__c: 'ApexClass:Bar',
+        sf_devops__Operation__c: 'add',
+        sf_devops__File_Path__c: 'path',
+        Type: 'ApexClass',
+        Name: 'Bar',
+      },
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sandbox.stub(Utils, 'getFormattedDeployComponentsByAyncOpId').resolves(deployedComponents);
+
+    outputService = getOutputService(false, true);
+    await outputService.displayEndResults();
+    expect(vacuum(ctx.stdout)).to.contain(
+      vacuum(`
+          === Deployed Source
+
+          Operation Name Type      Path 
+          ───────── ──── ───────── ──── 
+          add       Foo  ApexClass path 
+          add       Bar  ApexClass path  
+            `)
+    );
+  });
+
+  test.stdout().it('does not prints the deployed components table when verbose flag is not provided', async (ctx) => {
+    const deployedComponents: DeployComponent[] = [
+      {
+        sf_devops__Source_Component__c: 'ApexClass:Foo',
+        sf_devops__Operation__c: 'add',
+        sf_devops__File_Path__c: 'path',
+        Type: 'ApexClass',
+        Name: 'Foo',
+      },
+      {
+        sf_devops__Source_Component__c: 'ApexClass:Bar',
+        sf_devops__Operation__c: 'add',
+        sf_devops__File_Path__c: 'path',
+        Type: 'ApexClass',
+        Name: 'Bar',
+      },
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sandbox.stub(Utils, 'getFormattedDeployComponentsByAyncOpId').resolves(deployedComponents);
+
+    outputService = getOutputService(false, false);
+    await outputService.displayEndResults();
+    expect(ctx.stdout).to.not.contain('=== Deployed Source');
+  });
+
+  function getOutputService(conciseFlag: boolean, verboseFlag: boolean): ResumeCommandOutputService {
+    return new ResumeCommandOutputService(
+      buildResumeFlags(conciseFlag, verboseFlag),
+      TEST_OPERATION_TYPE,
+      sinon.createStubInstance(Connection)
+    );
+  }
+
+  function buildResumeFlags(conciseFlag: boolean, verboseFlag: boolean): ResumeFlags<typeof SfCommand> {
+    return {
+      concise: conciseFlag,
+      'devops-center-username': undefined,
+      'job-id': undefined,
+      'use-most-recent': true,
+      verbose: verboseFlag,
+      wait: Duration.minutes(4),
+      json: false,
+    };
+  }
+});


### PR DESCRIPTION
### What does this PR do?
Adds verbosity flags to resume command.
### What issues does this PR fix or reference?

[Insert GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NG4OJYA1/view)

### Functionality Before

**sf project deploy pipeline resume** does not have --concise and --verbose flags.

### Functionality After

**sf project deploy pipeline resume** has --concise and --verbose flags.
