### PR TITLE
Npiccolo/stall

### DIFF
--- a/src/common/base/abstractAsyncOperation.ts
+++ b/src/common/base/abstractAsyncOperation.ts
@@ -98,12 +98,23 @@ export abstract class AsyncCommand extends SfCommand<AsyncOperationResultJson> {
    * @param wait
    */
   private async startMonitoring(wait: Duration): Promise<void> {
-    const streamer: DoceMonitor = getAsyncOperationStreamer(
-      this.targetOrg,
-      wait,
-      this.asyncOperationId,
-      this.outputService
+    const asyncJob: AsyncOperationResult = await fetchAsyncOperationResult(
+      this.targetOrg.getConnection(),
+      this.asyncOperationId
     );
-    await streamer.monitor();
+    if (
+      asyncJob.sf_devops__Status__c === undefined ||
+      asyncJob.sf_devops__Status__c === AsyncOperationStatus.InProgress
+    ) {
+      const streamer: DoceMonitor = getAsyncOperationStreamer(
+        this.targetOrg,
+        wait,
+        this.asyncOperationId,
+        this.outputService
+      );
+      await streamer.monitor();
+    } else {
+      this.outputService.printAorStatus(asyncJob);
+    }
   }
 }

--- a/test/commands/project/deploy/pipeline/start.test.ts
+++ b/test/commands/project/deploy/pipeline/start.test.ts
@@ -361,8 +361,8 @@ describe('project deploy pipeline start', () => {
       // Mock the events streaming and the output service
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sandbox.stub(StreamingClient, 'create' as any).callsFake(stubStreamingClient);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       monitorStub = sandbox
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .stub(AsyncOpStreaming.prototype, 'monitor' as any)
         .returns({ completed: true, payload: {} });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### What does this PR do?
Handles fast transition to concluded state for an AOR during any async operation running on the CLI.

### What issues does this PR fix or reference?

@[W-13065560](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Pp0vJYAR/view)@

### Functionality Before

Not handled

### Functionality After

If transitioned fast, we display the status of the AOR.
