### PR TITLE
chore: remove caret on oclif/core dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
-    "@oclif/core": "^2.11.5",
+    "@oclif/core": "2.11.5",
     "@salesforce/core": "^5.1.4",
     "@salesforce/kit": "^3.0.7",
     "@salesforce/sf-plugins-core": "^3.1.14",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
-    "@oclif/core": "2.11.5",
+    "@oclif/core": "2.11.8",
     "@salesforce/core": "^5.1.4",
     "@salesforce/kit": "^3.0.7",
     "@salesforce/sf-plugins-core": "^3.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@^2.11.1", "@oclif/core@^2.11.5", "@oclif/core@^2.11.7", "@oclif/core@^2.9.4":
+"@oclif/core@2.11.8", "@oclif/core@^2.11.1", "@oclif/core@^2.11.7", "@oclif/core@^2.9.4":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.11.8.tgz#780c4fdf53e8569cf754c2a8fefcc7ddeacf1747"
   integrity sha512-GILmztcHBzze45GvxRpUvqQI5nM26kSE/Q21Y+6DtMR+C8etM/hFW26D3uqIAbGlGtg5QEZZ6pjA/Fqgz+gl3A==


### PR DESCRIPTION
### What does this PR do?
Remove caret from `@oclif/core` dev dependency so it can be used in CodeBuilder.
### What issues does this PR fix or reference?

[W-14026594](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ZXMS4YAP/view)

### Functionality Before

Plugin commands fail with error `TypeError: this.config.getPluginsList is not a function` when executed in CodeBuilder.

### Functionality After

Commands run as expected.
