### PR TITLE
fix: add package prefix to CDC channel name

### DIFF
--- a/src/common/base/abstractAsyncOperation.ts
+++ b/src/common/base/abstractAsyncOperation.ts
@@ -60,7 +60,7 @@ export abstract class AsyncCommand extends SfCommand<AsyncOperationResultJson> {
    * @returns
    */
   protected catch(error: Error | SfError): Promise<SfCommand.Error> {
-    if (error.name.includes('GenericTimeoutError')) {
+    if (error.name && error.name.includes('GenericTimeoutError')) {
       const err = messages.createError('error.ClientTimeout', [this.config.bin, this.baseCommand]);
       return super.catch({ ...error, name: err.name, message: err.message, code: err.code });
     }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -6,7 +6,7 @@
  */
 
 export const APPROVED = 'Approved';
-export const ASYNC_OPERATION_CDC = '/data/Async_Operation_Result__ChangeEvent';
+export const ASYNC_OPERATION_CDC = '/data/sf_devops__Async_Operation_Result__ChangeEvent';
 export const REST_PROMOTE_BASE_URL = '/services/apexrest/sf_devops/pipeline/promote/v1/';
 export const HTTP_CONFLICT_CODE = 'CONFLICT';
 export enum AsyncOperationType {


### PR DESCRIPTION
### What does this PR do?
Updates the DCD channel name to include the namespace prefix `sf_devops__`.
### What issues does this PR fix or reference?

[W-14050465](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ZkuNKYAZ/view)

### Functionality Before

The plugin attempts to subscribe to DCD channel to monitor the progress operation. In production orgs it fails because the channel name is missing the prefix.

### Functionality After

The plugin successfully subscribes to DCD channel.
