### PR TITLE
Fix for quick deployment

### DIFF
--- a/src/common/outputService/aorOutputService.ts
+++ b/src/common/outputService/aorOutputService.ts
@@ -76,8 +76,7 @@ export abstract class AbstractAorOutputService<T extends AorOutputFlags>
       } else {
         console.log(red(aor.sf_devops__Message__c));
       }
-    } else {
-      // aor.sf_devops__Status__c == undefined || AsyncOperationStatus.InProgress
+    } else if (aor.sf_devops__Message__c) {
       console.log(aor.sf_devops__Message__c);
     }
 

--- a/src/common/selectors/deploymentResultsSelector.ts
+++ b/src/common/selectors/deploymentResultsSelector.ts
@@ -62,9 +62,11 @@ export async function selectOneDeploymentResultWithChangeBundleInstallsByAsyncJo
   asyncJobId: string
 ): Promise<CheckDeploymentResultWithChangeBundleInstalls | null> {
   const queryStr = `SELECT sf_devops__Check_Deploy__c, sf_devops__Deployment_Id__c, sf_devops__Check_Deploy_Status__r.sf_devops__Status__c,
-                    (SELECT sf_devops__Environment__c FROM sf_devops__Change_Bundle_Installs__r)
+                      (SELECT sf_devops__Environment__c FROM sf_devops__Change_Bundle_Installs__r)
                     FROM sf_devops__Deployment_Result__c  
-                    WHERE sf_devops__Check_Deploy_Status__c = '${asyncJobId}' AND sf_devops__Check_Deploy__c = TRUE`;
+                    WHERE sf_devops__Check_Deploy_Status__c = '${asyncJobId}'
+                      AND sf_devops__Check_Deploy__c = TRUE
+                      AND Id IN (SELECT sf_devops__Deployment_Result__c FROM sf_devops__Change_Bundle_Install__c)`;
 
   const resp: QueryResult<CheckDeploymentResultWithChangeBundleInstalls> = await runSafeQuery(con, queryStr, true);
   return resp.totalSize > 0 ? resp.records[0] : null;

--- a/test/commands/project/deploy/pipeline/quick.test.ts
+++ b/test/commands/project/deploy/pipeline/quick.test.ts
@@ -368,6 +368,22 @@ describe('project deploy pipeline quick', () => {
             "We can't perform the quick deployment for the specified job ID because the validate-only deployment failed or is still running. If the validate-only deployment failed, fix the issue and re-run it. If the validate-only deployment was successful, try this command again later."
           );
         });
+
+      test
+        .stdout()
+        .stderr()
+        .do(() => {
+          queryStub = sinon.stub().returns(getQueryResultMock([]));
+          requestMock = sinon.stub().resolves({ jobId: mockReturnedAorId });
+          stubStreamer();
+        })
+        .command(['project deploy pipeline quick', `-i=${mockValidatedAorId}`])
+        .catch(() => {})
+        .it('display an error message when the deployment result does not have CBIs', (ctx) => {
+          expect(ctx.stderr).to.contain(
+            " The job ID is invalid for the quick deployment. Verify that a deployment validation was run or hasn't expired, and that you specified the correct job ID. Then try again."
+          );
+        });
     });
 
     describe('stream aor status', () => {

--- a/test/common/outputService/aorOutputService.test.ts
+++ b/test/common/outputService/aorOutputService.test.ts
@@ -43,7 +43,7 @@ describe('aorOutputService', () => {
       expect(ctx.stdout).to.contain(message);
     });
 
-    test.stdout().it('handles the print of an In Progress aor status', (ctx) => {
+    test.stdout().it('handles the print of an In Progress aor status when the message is valid', (ctx) => {
       const status = AsyncOperationStatus.InProgress;
       const message = 'This should be printed';
       const aor: AsyncOperationResult = {
@@ -54,6 +54,18 @@ describe('aorOutputService', () => {
       };
       outputService.printAorStatus(aor);
       expect(ctx.stdout).to.contain(message);
+    });
+
+    test.stdout().it('handles the print of an In Progress aor status when the message is undefined', (ctx) => {
+      const status = AsyncOperationStatus.InProgress;
+      const aor: AsyncOperationResult = {
+        Id: 'Id',
+        sf_devops__Error_Details__c: undefined,
+        sf_devops__Status__c: status,
+        sf_devops__Message__c: undefined,
+      };
+      outputService.printAorStatus(aor);
+      expect(ctx.stdout).to.not.contain(undefined);
     });
 
     test.stdout().it('handles the print of a Completed aor status', (ctx) => {

--- a/test/common/selectors/deploymentResultsSelector.test.ts
+++ b/test/common/selectors/deploymentResultsSelector.test.ts
@@ -158,9 +158,11 @@ describe('DeploymentResult selector', () => {
       'SELECT sf_devops__Check_Deploy__c, sf_devops__Deployment_Id__c, sf_devops__Check_Deploy_Status__r.sf_devops__Status__c'
     );
     expect(builderArgs[0]).to.contain('(SELECT sf_devops__Environment__c FROM sf_devops__Change_Bundle_Installs__r)');
-    // verify we used the correct filter
+    // verify we used the correct filters
+    expect(builderArgs[0]).to.contain(`WHERE sf_devops__Check_Deploy_Status__c = '${mockAorId}'`);
+    expect(builderArgs[0]).to.contain('AND sf_devops__Check_Deploy__c = TRUE');
     expect(builderArgs[0]).to.contain(
-      `WHERE sf_devops__Check_Deploy_Status__c = '${mockAorId}' AND sf_devops__Check_Deploy__c = TRUE`
+      'AND Id IN (SELECT sf_devops__Deployment_Result__c FROM sf_devops__Change_Bundle_Install__c)'
     );
   });
 


### PR DESCRIPTION
### What does this PR do?
Adds validations for two error cases:

- Validate that the deployment result for a quick deploy has CBI associated.
- Validate that we don't print undefined when monitoring the AOR progress.

### What issues does this PR fix or reference?

[@W-14002948@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Z9PyCYAV/view)

[@W-14002980@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Z9ifMYAR/view)
