### PR TITLE
fix: update name of --tests flag (from --run-tests)

### DIFF
--- a/messages/promoteFlags.md
+++ b/messages/promoteFlags.md
@@ -36,7 +36,7 @@ Valid values are:
 
 - NoTestRun — No tests are run. This test level applies only to deployments to development environments, such as sandbox, Developer Edition, or trial orgs. This test level is the default for development environments.
 
-- RunSpecifiedTests — Runs only the tests that you specify with the --run-tests flag. Code coverage requirements differ from the default coverage requirements when using this test level. Executed tests must comprise a minimum of 75% code coverage for each class and trigger in the deployment package. This coverage is computed for each class and trigger individually and is different than the overall coverage percentage.
+- RunSpecifiedTests — Runs only the tests that you specify with the --tests flag. Code coverage requirements differ from the default coverage requirements when using this test level. Executed tests must comprise a minimum of 75% code coverage for each class and trigger in the deployment package. This coverage is computed for each class and trigger individually and is different than the overall coverage percentage.
 
 - RunLocalTests — All tests in your org are run, except the ones that originate from installed managed and unlocked packages. This test level is the default for production deployments that include Apex classes or triggers.
 


### PR DESCRIPTION
### What does this PR do?

Fixes incorrect flag name in help for "project deploy pipeline start" and "project deploy pipeline validate" (--run-tests in stead of correct --tests)

### What issues does this PR fix or reference?

@W-14191788@
