### PR TITLE
fix: remove `default` from wait flag

### DIFF
--- a/src/common/flags/flags.ts
+++ b/src/common/flags/flags.ts
@@ -31,7 +31,6 @@ export const wait: OptionFlag<Duration> = Flags.duration({
   summary: messages.getMessage('flags.wait.summary'),
   description: messages.getMessage('flags.wait.description'),
   defaultValue: 33,
-  default: Duration.minutes(33),
   helpValue: '<minutes>',
   min: 3,
   exclusive: ['async'],

--- a/test/common/flags.test.ts
+++ b/test/common/flags.test.ts
@@ -212,7 +212,7 @@ describe('waitFlag', () => {
     const out = await Parser.parse([], {
       flags: { wait },
     });
-    expect(out.flags.wait).to.deep.equal(wait.default);
+    expect(out.flags.wait).to.deep.equal(Duration.minutes(33));
   });
 
   it('wait and async flags are mutually exclusive', async () => {


### PR DESCRIPTION
### What does this PR do?

Setting `default` to a complex value like `Duration` causes help to show ` --wait=<value>     [default: [object Object]]`. The `duration` flag from sf-plugins-core will set a `defaultHelp` that will render the `Duration` class to a readable string ([PR](https://github.com/salesforcecli/sf-plugins-core/pull/514))

### What issues does this PR fix or reference?

@W-14625639@
