### PR TITLE
docs: Update NoDefaultDoceEnv error message

### DIFF
--- a/messages/commonFlags.md
+++ b/messages/commonFlags.md
@@ -50,4 +50,4 @@ Show concise output of the command result.
 
 # errors.NoDefaultDoceEnv
 
-You must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.
+The first time you run any DevOps Center CLI command, you must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.

--- a/messages/commonFlags.md
+++ b/messages/commonFlags.md
@@ -50,4 +50,4 @@ Show concise output of the command result.
 
 # errors.NoDefaultDoceEnv
 
-The first time you run any DevOps Center CLI command, you must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.
+Before you run any DevOps Center CLI commands, you must first authorize the org in which DevOps Center is installed. Then when you run a command, you must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.

--- a/messages/commonFlags.md
+++ b/messages/commonFlags.md
@@ -50,4 +50,4 @@ Show concise output of the command result.
 
 # errors.NoDefaultDoceEnv
 
-Before you run any DevOps Center CLI commands, you must first authorize the org in which DevOps Center is installed. Be sure that the DevOps Center org is authorized, and that you indicated the DevOps Center org username when running the command (--devops-center-username) or set the configuration variable for target-devops-center (sf config set), and try again.
+Before you run a DevOps Center CLI command, you must first use one of the "org login" commands to authorize the org in which DevOps Center is installed. Then, when you run a DevOps Center command, be sure that you specify the DevOps Center org username with the "--devops-center-username" flag. Alternatively, you can set the "target-devops-center" configuration variable to the username with the "config set" command.

--- a/messages/commonFlags.md
+++ b/messages/commonFlags.md
@@ -50,4 +50,4 @@ Show concise output of the command result.
 
 # errors.NoDefaultDoceEnv
 
-Before you run any DevOps Center CLI commands, you must first authorize the org in which DevOps Center is installed. Then when you run a command, you must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.
+Before you run any DevOps Center CLI commands, you must first authorize the org in which DevOps Center is installed. Be sure that the DevOps Center org is authorized, and that you indicated the DevOps Center org username when running the command (--devops-center-username) or set the configuration variable for target-devops-center (sf config set), and try again.

--- a/test/commands/project/deploy/pipeline/quick.test.ts
+++ b/test/commands/project/deploy/pipeline/quick.test.ts
@@ -122,7 +122,7 @@ describe('project deploy pipeline quick', () => {
       .catch(() => {})
       .it('runs project deploy pipeline quick without specifying any target Devops Center org', (ctx) => {
         expect(ctx.stderr).to.contain(
-          'You must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.'
+          'Before you run a DevOps Center CLI command, you must first use one of the "org login" commands to authorize the org in which DevOps Center is installed. Then, when you run a DevOps Center command, be sure that you specify the DevOps Center org username with the "--devops-center-username" flag. Alternatively, you can set the "target-devops-center" configuration variable to the username with the "config set" command.'
         );
       });
   });

--- a/test/commands/project/deploy/pipeline/report.test.ts
+++ b/test/commands/project/deploy/pipeline/report.test.ts
@@ -58,7 +58,7 @@ describe('project deploy pipeline report', () => {
       .catch(() => {})
       .it('runs project deploy pipeline report without specifying any target Devops Center org', (ctx) => {
         expect(ctx.stderr).to.contain(
-          'You must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.'
+          'Before you run a DevOps Center CLI command, you must first use one of the "org login" commands to authorize the org in which DevOps Center is installed. Then, when you run a DevOps Center command, be sure that you specify the DevOps Center org username with the "--devops-center-username" flag. Alternatively, you can set the "target-devops-center" configuration variable to the username with the "config set" command.'
         );
       });
   });

--- a/test/commands/project/deploy/pipeline/resume.test.ts
+++ b/test/commands/project/deploy/pipeline/resume.test.ts
@@ -61,7 +61,7 @@ describe('project deploy pipeline resume', () => {
       .catch(() => {})
       .it('runs project deploy pipeline resume without specifying any target Devops Center org', (ctx) => {
         expect(ctx.stderr).to.contain(
-          'You must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.'
+          'Before you run a DevOps Center CLI command, you must first use one of the "org login" commands to authorize the org in which DevOps Center is installed. Then, when you run a DevOps Center command, be sure that you specify the DevOps Center org username with the "--devops-center-username" flag. Alternatively, you can set the "target-devops-center" configuration variable to the username with the "config set" command.'
         );
       });
   });

--- a/test/common/flags.test.ts
+++ b/test/common/flags.test.ts
@@ -118,7 +118,7 @@ describe('requiredDoceOrgFlag', () => {
     } catch (err) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(err.message).to.include(
-        'You must specify the DevOps Center org username by indicating the --devops-center-username flag on the command line or by setting the target-devops-center configuration variable.'
+        'Before you run a DevOps Center CLI command, you must first use one of the "org login" commands to authorize the org in which DevOps Center is installed. Then, when you run a DevOps Center command, be sure that you specify the DevOps Center org username with the "--devops-center-username" flag. Alternatively, you can set the "target-devops-center" configuration variable to the username with the "config set" command.'
       );
     }
   });


### PR DESCRIPTION
Clarify that all DOCe commands need the DOCe org authorized the first time they run them

### What does this PR do?
Update NoDefaultDoceEnv error message to include info about authorizing DOCe install org

### What issues does this PR fix or reference?

@W-15774563@
